### PR TITLE
Fix cluster on ESIP qhub and SlurmCluster import

### DIFF
--- a/gallery/streamflow/02_nwm_benchmark_analysis.ipynb
+++ b/gallery/streamflow/02_nwm_benchmark_analysis.ipynb
@@ -38,7 +38,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_jobqueue import SLURMCluster\n",
     "from dask.distributed import Client, LocalCluster\n",
     "import dask.bag as db\n",
     "\n",
@@ -67,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resource = 'tallgrass' #denali, tallgrass, local, esip-qhub-gateway-v0.4"
+    "resource = 'esip-qhub-gateway-v0.4' #denali, tallgrass, local, esip-qhub-gateway-v0.4"
    ]
   },
   {
@@ -97,6 +96,7 @@
     "        client = Client(cluster)\n",
     "    \n",
     "    elif resource == 'tallgrass':\n",
+    "        from dask_jobqueue import SLURMCluster\n",
     "        cluster = SLURMCluster(queue='cpu', cores=1, interface='ib0',\n",
     "                               job_extra=['--nodes=1', '--ntasks-per-node=1', '--cpus-per-task=1'],\n",
     "                               memory='6GB')\n",
@@ -111,7 +111,7 @@
     "        cluster = LocalCluster(threads_per_worker=n_cores)\n",
     "        client = Client(cluster)\n",
     "        \n",
-    "    elif cluster_type in ['esip-qhub-gateway-v0.4']:   \n",
+    "    elif resource in ['esip-qhub-gateway-v0.4']:   \n",
     "        import sys, os\n",
     "        sys.path.append(os.path.join(os.environ['HOME'],'shared','users','lib'))\n",
     "        import ebdpy as ebd\n",
@@ -274,9 +274,6 @@
    "execution_count": null,
    "id": "62327185-50a2-4fa6-bdd1-5a876c918001",
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": []
    },
    "outputs": [],
@@ -638,9 +635,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "users-pangeo",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-users-pangeo-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -652,7 +649,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We had a bug in the cluster generation on ESIP qhub and the SlurmCluster import is only necessary on Tallgrass